### PR TITLE
fix: give header background

### DIFF
--- a/src/client/app/page.module.css
+++ b/src/client/app/page.module.css
@@ -24,5 +24,5 @@ header.header {
   text-align: center;
   position: sticky;
   top: 0;
-  background-color: var(--background);
+  background-color: var(--neutral-background);
 }

--- a/src/client/components/galaxymap/GalaxyMap.tsx
+++ b/src/client/components/galaxymap/GalaxyMap.tsx
@@ -123,6 +123,7 @@ export default function Map(props: IMapProps) {
             position: "relative",
             top: offsetY,
             left: offsetX,
+            zIndex: -1,
           }}
           color="currentColor"
           fill="currentColor"

--- a/src/client/components/galaxymap/GalaxyMap.tsx
+++ b/src/client/components/galaxymap/GalaxyMap.tsx
@@ -123,7 +123,6 @@ export default function Map(props: IMapProps) {
             position: "relative",
             top: offsetY,
             left: offsetX,
-            zIndex: -1,
           }}
           color="currentColor"
           fill="currentColor"

--- a/src/client/components/galaxymap/PlanetMap.tsx
+++ b/src/client/components/galaxymap/PlanetMap.tsx
@@ -24,7 +24,9 @@ export default function PlanetMap(props: IPlanetMapProps) {
   const name = planet.name;
   const color = colorToCss(planet.color);
   const inFocus = planet.focusLevel >= zoomModifier;
+  console.log(`focuslevel: ${planet.focusLevel}, zoomModifier: ${zoomModifier}`);
   const radius = inFocus ? 3 : zoomModifier - planet.focusLevel < 10 ? 2 : 1;
+  if (zoomModifier - planet.focusLevel > 20) return;
 
   return (
     <g fill={color} stroke={color}>

--- a/src/client/components/galaxymap/PlanetMap.tsx
+++ b/src/client/components/galaxymap/PlanetMap.tsx
@@ -24,7 +24,6 @@ export default function PlanetMap(props: IPlanetMapProps) {
   const name = planet.name;
   const color = colorToCss(planet.color);
   const inFocus = planet.focusLevel >= zoomModifier;
-  console.log(`focuslevel: ${planet.focusLevel}, zoomModifier: ${zoomModifier}`);
   const radius = inFocus ? 3 : zoomModifier - planet.focusLevel < 10 ? 2 : 1;
   if (zoomModifier - planet.focusLevel > 20) return;
 

--- a/src/client/components/galaxymap/SpacelaneMap.tsx
+++ b/src/client/components/galaxymap/SpacelaneMap.tsx
@@ -27,10 +27,8 @@ export default function SpacelaneMap(props: ISpacelaneMapProps) {
   const yTwo = props.centerY - spacelane.yTwo / zoomModifier;
   const color = colorToCss(spacelane.color);
   const inFocus = spacelane.focusLevel >= zoomModifier;
-  const strokeWidth = inFocus
-    ? 2
-    : 1;
-    if (zoomModifier - spacelane.focusLevel > 5) return;
+  const strokeWidth = inFocus ? 2 : 1;
+  if (zoomModifier - spacelane.focusLevel > 5) return;
 
   return (
     <g fill={color} stroke={color}>

--- a/src/client/components/galaxymap/SpacelaneMap.tsx
+++ b/src/client/components/galaxymap/SpacelaneMap.tsx
@@ -28,10 +28,9 @@ export default function SpacelaneMap(props: ISpacelaneMapProps) {
   const color = colorToCss(spacelane.color);
   const inFocus = spacelane.focusLevel >= zoomModifier;
   const strokeWidth = inFocus
-    ? 3
-    : zoomModifier - spacelane.focusLevel < 10
-      ? 1
-      : 0;
+    ? 2
+    : 1;
+    if (zoomModifier - spacelane.focusLevel > 5) return;
 
   return (
     <g fill={color} stroke={color}>

--- a/src/client/components/nav.module.css
+++ b/src/client/components/nav.module.css
@@ -26,6 +26,6 @@ nav.nav {
 }
 
 .nav a:hover {
-  background-color: var(--foreground);
-  color: var(--background);
+  background-color: var(--neutral-text);
+  color: var(--neutral-background);
 }

--- a/src/service/Models/Map/FocusLevelConverter.cs
+++ b/src/service/Models/Map/FocusLevelConverter.cs
@@ -1,0 +1,19 @@
+namespace GalaxyMapSiteApi.Models.Map;
+
+public class FocusLevelConverter {
+    public static int convertFormap(int level) {
+        switch(level){
+            case 1:
+                return 100;
+            case 2:
+                return 40;
+            case 3:
+                return 20;
+            case 4:
+                return 10;
+            case 5:
+            default:
+                return 1;
+        }
+    }
+}

--- a/src/service/Models/Map/Spacelane.cs
+++ b/src/service/Models/Map/Spacelane.cs
@@ -18,7 +18,7 @@ public struct Spacelane{
         XTwo = spacelane.Destination.Coordinates.X;
         YTwo = spacelane.Destination.Coordinates.Y;
         Color = Enum.GetName(typeof(MapColor), MapColor.Gray) ?? "Gray";
-        FocusLevel = (10 - spacelane.Focus) * 10 + 1;
+        FocusLevel = FocusLevelConverter.convertFormap(spacelane.Focus);
     }
     #endregion Constructors
 }

--- a/src/service/Models/Map/System.cs
+++ b/src/service/Models/Map/System.cs
@@ -14,7 +14,7 @@ public struct System {
         X = system.Coordinates.X;
         Y = system.Coordinates.Y;
         Color = Enum.GetName(typeof(MapColor), MapColor.Gray) ?? "Gray";
-        FocusLevel = (10 - system.Focus) * 10 + 1;
+        FocusLevel = FocusLevelConverter.convertFormap(system.Focus);
     }
     #endregion Constructors
 }


### PR DESCRIPTION
## Summary

1. Give the header a background again 
    1. When we switched to themes we didn't update all css variables
    1. Give the map svg a negative z index so it goes behind other elements
1. Fade planets out of view entirely with low enough focus

## Test plan

`just run` locally and check

## Issues

- #50
- #37 