### PR TITLE
feat(component): show spacelane names

### DIFF
--- a/src/client/components/galaxymap/SpacelaneMap.tsx
+++ b/src/client/components/galaxymap/SpacelaneMap.tsx
@@ -25,14 +25,73 @@ export default function SpacelaneMap(props: ISpacelaneMapProps) {
   const yOne = props.centerY - spacelane.yOne / zoomModifier;
   const xTwo = props.centerX + spacelane.xTwo / zoomModifier;
   const yTwo = props.centerY - spacelane.yTwo / zoomModifier;
+  const name = spacelane.name;
   const color = colorToCss(spacelane.color);
   const inFocus = spacelane.focusLevel >= zoomModifier;
   const strokeWidth = inFocus ? 2 : 1;
   if (zoomModifier - spacelane.focusLevel > 5) return;
 
+  const textRotation =
+    (Math.atan((yTwo - yOne) / (xTwo - xOne)) * 180) / Math.PI;
+  const textPosition = getTextPosition(xOne, xTwo, yOne, yTwo, textRotation);
+
   return (
     <g fill={color} stroke={color}>
       <line x1={xOne} y1={yOne} x2={xTwo} y2={yTwo} strokeWidth={strokeWidth} />
+      {inFocus && checkIfSpaceForText(xOne, xTwo, yOne, yTwo, name) ? (
+        <text
+          x={textPosition.x}
+          y={textPosition.y}
+          transform={`rotate(${textRotation} ${textPosition.x} ${textPosition.y})`}
+          textAnchor="middle"
+          dominantBaseline="middle"
+        >
+          {name}
+        </text>
+      ) : null}
     </g>
+  );
+}
+
+function getTextPosition(
+  xOne: number,
+  xTwo: number,
+  yOne: number,
+  yTwo: number,
+  textRotation: number,
+) {
+  const textPosition = {
+    x: (xOne + xTwo) / 2,
+    y: (yOne + yTwo) / 2,
+  };
+  const xOffsetDirection = textRotation > 0 ? 1 : -1;
+  const offSet = 20;
+  if (Math.abs(xOne - xTwo) > Math.abs(yOne - yTwo)) {
+    textPosition.y =
+      textPosition.y -
+      (textPosition.y / (textPosition.x + textPosition.y)) * offSet;
+  } else {
+    textPosition.x =
+      textPosition.x +
+      (textPosition.x / (textPosition.x + textPosition.y)) *
+        offSet *
+        xOffsetDirection;
+  }
+
+  return textPosition;
+}
+
+function checkIfSpaceForText(
+  xOne: number,
+  xTwo: number,
+  yOne: number,
+  yTwo: number,
+  text: string,
+) {
+  const characterLength = 10;
+  const requiredLength = text.length * characterLength;
+  return (
+    Math.abs(xOne - xTwo) > requiredLength ||
+    Math.abs(yOne - yTwo) > requiredLength
   );
 }


### PR DESCRIPTION
## Summary

Show spacelane names.
- Only when zoomed in enough that there is enough space
- Names rotate to match angle of spacelane

## Test plan

- `just run` locally and test on desktop and mobile

## Issues

- Closes #34 