### PR TITLE
ci: use action-release-changelog and create separate publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish
+permissions: read-all
+on:
+  release:
+    types: [published]
+jobs:
+    publish-aspnet:
+      runs-on: ubuntu-latest
+      name: Publish Image
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+          with:
+            persist-credentials: false
+        - name: Publish Image
+          uses: outoforbitdev/action-docker-publish@v3.0.0
+          with:
+            docker-username: ${{ vars.DOCKER_USERNAME }}
+            docker-token: ${{ secrets.DOCKER_TOKEN }}
+            image-name: ${{ vars.IMAGE_NAME }}
+            image-tag: "${{ github.ref_name }}"
+            platforms: "linux/amd64"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,19 +4,19 @@ on:
   release:
     types: [published]
 jobs:
-    publish-aspnet:
-      runs-on: ubuntu-latest
-      name: Publish Image
-      steps:
-        - name: Checkout
-          uses: actions/checkout@v4
-          with:
-            persist-credentials: false
-        - name: Publish Image
-          uses: outoforbitdev/action-docker-publish@v3.0.0
-          with:
-            docker-username: ${{ vars.DOCKER_USERNAME }}
-            docker-token: ${{ secrets.DOCKER_TOKEN }}
-            image-name: ${{ vars.IMAGE_NAME }}
-            image-tag: "${{ github.ref_name }}"
-            platforms: "linux/amd64"
+  publish-aspnet:
+    runs-on: ubuntu-latest
+    name: Publish Image
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Publish Image
+        uses: outoforbitdev/action-docker-publish@v3.0.0
+        with:
+          docker-username: ${{ vars.DOCKER_USERNAME }}
+          docker-token: ${{ secrets.DOCKER_TOKEN }}
+          image-name: ${{ vars.IMAGE_NAME }}
+          image-tag: "${{ github.ref_name }}"
+          platforms: "linux/amd64"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,37 +10,15 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    name: Publish Github Release
-    outputs:
-      version-released: ${{ steps.semantic-release.outputs.version-released }}
-      next-version: ${{ steps.semantic-release.outputs.next-version }}
+    name: Create Github Release
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Publish Release
-        uses: outoforbitdev/action-semantic-release@v1.6.2
+      - name: Create Release
+        uses: outoforbitdev/action-release-changelog@v0.0.10
         id: semantic-release
         with:
           github-token: ${{ secrets.RELEASE_TOKEN }}
-          skip-changelog: ${{ github.ref_name != 'main' }}
-  publish-aspnet:
-    runs-on: ubuntu-latest
-    name: Publish Image
-    needs:
-      - release
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - name: Publish Image
-        uses: outoforbitdev/action-docker-publish@v3.0.0
-        if: ${{ needs.release.outputs.version-released }}
-        with:
-          docker-username: ${{ vars.DOCKER_USERNAME }}
-          docker-token: ${{ secrets.DOCKER_TOKEN }}
-          image-name: ${{ vars.IMAGE_NAME }}
-          image-tag: "${{ needs.release.outputs.next-version }}"
-          platforms: "linux/amd64"
+          repository: ${{ github.repository }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.0 (2025-02-13)
+
+### Features
+
+- Add options window to the map
+
 ## [1.0.1](https://github.com/outoforbitdev/app-galaxy-map/compare/v1.0.0...v1.0.1) (2024-11-16)
 
 


### PR DESCRIPTION
## Summary
- Replace `action-semantic-release` with `action-release-changelog`
- Create a new `Publish` workflow to run after publishing a release