### PR TITLE
feat: add planets and governments

### DIFF
--- a/.local/db/add-db-data.sql
+++ b/.local/db/add-db-data.sql
@@ -1,3 +1,8 @@
 TRUNCATE solar_systems CASCADE;
+TRUNCATE governments CASCADE;
 COPY solar_systems FROM '/data/db/solar-systems.csv' DELIMITER ',' HEADER;
 COPY spacelanes FROM '/data/db/spacelanes.csv' DELIMITER ',' HEADER;
+COPY planets FROM '/data/db/planets.csv' DELIMITER ',' HEADER;
+COPY governments FROM '/data/db/governments.csv' DELIMITER ',' HEADER;
+COPY planet_governments FROM '/data/db/planet-governments.csv' DELIMITER ',' HEADER;
+COPY government_governments FROM '/data/db/government-governments.csv' DELIMITER ',' HEADER;

--- a/.local/db/government-governments.csv
+++ b/.local/db/government-governments.csv
@@ -1,0 +1,3 @@
+ChildGovernment,ParentGovernment,Relationship
+Capital,Core,Member
+Trade Center,Core,Member

--- a/.local/db/governments.csv
+++ b/.local/db/governments.csv
@@ -1,0 +1,7 @@
+Name,Color
+Core,Red
+Outer,Blue
+Insurgents,Green
+Capital,Yellow
+Trade Center,Magenta
+Corporate,Aqua

--- a/.local/db/planet-governments.csv
+++ b/.local/db/planet-governments.csv
@@ -1,0 +1,16 @@
+Planet,Government,Relationship
+Capital Planet,Capital,Member
+Capital Farm,Capital,Member
+Capital Mine,Capital,Member
+Trade Center,Trade Center,Member
+Blue Trade,Trade Center,Member
+Outer Capital,Outer,Member
+Desert,Outer,Member
+Bug Desert,Outer,Member
+Corporate Capital,Corporate,Member
+Corporate Terminal,Corporate,Member
+Ocean,Insurgents,Member
+Forest,Insurgents,Member
+Matriarch,Insurgents,Member
+Mercenaries,Insurgents,Member
+Shipbuilder Alpha,Core,Member

--- a/.local/db/planet-governments.csv
+++ b/.local/db/planet-governments.csv
@@ -6,7 +6,6 @@ Trade Center,Trade Center,Member
 Blue Trade,Trade Center,Member
 Outer Capital,Outer,Member
 Desert,Outer,Member
-Bug Desert,Outer,Member
 Corporate Capital,Corporate,Member
 Corporate Terminal,Corporate,Member
 Ocean,Insurgents,Member

--- a/.local/db/planets.csv
+++ b/.local/db/planets.csv
@@ -5,6 +5,8 @@ Capital Mine,Capital III
 Trade Center,Trade Center
 Blue Trade,Blue Trade Center
 Outer Capital,Outer Capital
+Outer Capital II,Outer Capital
+Outer Capital III,Outer Capital
 Desert,Desert
 Bug Desert,Bug Desert
 Corporate Capital,Corporate Capital

--- a/.local/db/planets.csv
+++ b/.local/db/planets.csv
@@ -1,0 +1,16 @@
+Name,System
+Capital Planet,Capital Prime
+Capital Farm,Capital II
+Capital Mine,Capital III
+Trade Center,Trade Center
+Blue Trade,Blue Trade Center
+Outer Capital,Outer Capital
+Desert,Desert
+Bug Desert,Bug Desert
+Corporate Capital,Corporate Capital
+Corporate Terminal,Corporate Terminal
+Ocean,Ocean
+Forest,Forest
+Matriarch,Matriarch
+Mercenaries,Mercenaries
+Shipbuilder Alpha,Shipbuilder Alpha

--- a/.local/db/solar-systems.csv
+++ b/.local/db/solar-systems.csv
@@ -14,3 +14,4 @@ Forest,4750,125,Bears,Mid,3
 Matriarch,3531,531,Matriarch Cluster,Inner,2
 Mercenaries,3681,2723,Mercenary,Outer,2
 Shipbuilder Alpha,1859,-578,Shipbuilder,Core,5
+Empty System,1328,-63,Empty,Core,3

--- a/.local/run.sh
+++ b/.local/run.sh
@@ -2,4 +2,4 @@
 
 clear
 cd src/client && npm run dev &
-cd src/service && dotnet run
+cd src/service && dotnet watch --non-interactive

--- a/Justfile
+++ b/Justfile
@@ -1,4 +1,4 @@
-app_name := "galaxy-map-site"
+app_name := "app-galaxy-map"
 port := "1798"
 api_port := "1799"
 
@@ -28,12 +28,13 @@ build: clean
     open http://localhost:{{port}}
 
 clean: stop
+    -docker compose -f .local/docker-compose.yml  rm -f
+    -docker rm {{app_name}}
     -docker rmi {{app_name}}
 
 stop:
+    -docker compose -f .local/docker-compose.yml  stop
     -docker stop {{app_name}}
-    -docker rm {{app_name}}
-    -docker compose stop
 
 get-ip:
     echo "http://$(ipconfig getifaddr en0):{{port}}"

--- a/src/service/Controllers/Planets.cs
+++ b/src/service/Controllers/Planets.cs
@@ -35,8 +35,14 @@ public class PlanetsController : ControllerBase
     [HttpGet(Name = "GetPlanets")]
     public async Task<ActionResult<IEnumerable<Models.Map.System>>> Get()
     {
-        List<Models.System> systems = await _context.Systems.ToListAsync();
+        List<Models.System> systems = 
+            await _context.Systems
+                .Include(s => s.Planets)
+                    .ThenInclude(p => p.ParentGovernments)
+                        .ThenInclude(p => p.Government)
+                .ToListAsync();
         List<Models.Map.System> data = systems.ConvertAll(s => new Models.Map.System(s));
+        List<Models.Planet> planets = await _context.Planets.ToListAsync();
         // planetList.Sort((a, b) => a.FocusLevel - b.FocusLevel);
         return data;
     }

--- a/src/service/Data/GalaxyMapContext.cs
+++ b/src/service/Data/GalaxyMapContext.cs
@@ -4,25 +4,91 @@ namespace GalaxyMapSiteApi.Data;
 
 public class GalaxyMapContext : DbContext {
     public GalaxyMapContext(DbContextOptions<GalaxyMapContext> options) : base(options) { }
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder
+            .UseLazyLoadingProxies();
+    }
     public DbSet<Models.System> Systems { get; set;}
     public DbSet<Models.Spacelane> Spacelanes { get; set;}
+    public DbSet<Models.Planet> Planets {get; set; }
+    public DbSet<Models.Government> Governments {get; set; }
+    public DbSet<Models.GovernmentGovernment> GovernmentGovernments {get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        modelBuilder.Entity<Models.System>()
-            .HasKey(s => s.Name);
-        modelBuilder.Entity<Models.Spacelane>()
-            .HasOne(s => s.Origin)
-            .WithMany()
-            .HasForeignKey(s => s.OriginId)
+        modelBuilder.Entity<Models.Government>()
+            .HasMany(g => g.ParentGovernments)
+            .WithOne(g => g.ChildGovernment)
+            .HasForeignKey(g => g.ChildGovernmentId)
             .IsRequired();
-        modelBuilder.Entity<Models.Spacelane>()
-            .HasOne(s => s.Destination)
-            .WithMany()
-            .HasForeignKey(s => s.DestinationId)
-            .IsRequired();
-        modelBuilder.Entity<Models.Spacelane>()
-            .HasNoKey();
+    //     #region System
+    //     modelBuilder.Entity<Models.System>()
+    //         .HasKey(s => s.Name);
+    //     #endregion System
+    //     #region Spacelane
+    //     modelBuilder.Entity<Models.Spacelane>()
+    //         .HasOne(s => s.Origin)
+    //         .WithMany()
+    //         .HasForeignKey(s => s.OriginId)
+    //         .IsRequired();
+    //     modelBuilder.Entity<Models.Spacelane>()
+    //         .HasOne(s => s.Destination)
+    //         .WithMany()
+    //         .HasForeignKey(s => s.DestinationId)
+    //         .IsRequired();
+    //     modelBuilder.Entity<Models.Spacelane>()
+    //         .HasNoKey();
+    //     #endregion Spacelane
+    //     #region Planet
+    //     modelBuilder.Entity<Models.Planet>()
+    //         .HasKey(p => p.Name);
+    //     modelBuilder.Entity<Models.Planet>()
+    //         .HasMany(p => p.ParentGovernments)
+    //         .WithOne(p => p.Planet)
+    //         .HasForeignKey(p => p.PlanetId)
+    //         .IsRequired();
+    //     #endregion Planet
+    //     #region Government
+    //     modelBuilder.Entity<Models.Government>()
+    //         .HasKey(g => g.Name);
+    //     modelBuilder.Entity<Models.Government>()
+    //         .Property(g => g.Color)
+    //             .HasConversion(
+    //                 v => v.ToString(),
+    //                 v => (MapColor)Enum.Parse(typeof(MapColor), v));
+    //     #endregion Government
+    //     #region GovernmentGovernment
+    //     modelBuilder.Entity<Models.GovernmentGovernment>()
+    //         .HasOne(g => g.ChildGovernment)
+    //         .WithMany()
+    //         .HasForeignKey(g => g.ChildGovernmentId)
+    //         .IsRequired();
+    //     modelBuilder.Entity<Models.GovernmentGovernment>()
+    //         .HasOne(g => g.ParentGovernment)
+    //         .WithMany()
+    //         .HasForeignKey(g => g.ParentGovernmentId)
+    //         .IsRequired();
+    //     modelBuilder.Entity<Models.GovernmentGovernment>()
+    //         .HasNoKey()
+    //         .Property(g => g.Relationship)
+    //             .HasConversion(
+    //                 v => v.ToString(),
+    //                 v => (GovernmentRelationship)Enum.Parse(typeof(GovernmentRelationship), v));
+    //     #endregion GovernmentGovernment
+    //     #region PlanetGovernment
+    //     modelBuilder.Entity<Models.PlanetGovernment>()
+    //         .HasOne(p => p.Government)
+    //         .WithMany()
+    //         .HasForeignKey(p => p.GovernmentId)
+    //         .IsRequired();
+    //     modelBuilder.Entity<Models.PlanetGovernment>()
+    //         .HasNoKey()
+    //         .Property(p => p.Relationship)
+    //             .HasConversion(
+    //                 v => v.ToString(),
+    //                 v => (GovernmentRelationship)Enum.Parse(typeof(GovernmentRelationship), v));
+    //     #endregion PlanetGovernment
     }
 
 }

--- a/src/service/Data/GalaxyMapContext.cs
+++ b/src/service/Data/GalaxyMapContext.cs
@@ -22,61 +22,6 @@ public class GalaxyMapContext : DbContext {
             .WithOne(g => g.ChildGovernment)
             .HasForeignKey(g => g.ChildGovernmentId)
             .IsRequired();
-    //     #region System
-    //     modelBuilder.Entity<Models.System>()
-    //         .HasKey(s => s.Name);
-    //     #endregion System
-    //     #region Spacelane
-    //     modelBuilder.Entity<Models.Spacelane>()
-    //         .HasOne(s => s.Origin)
-    //         .WithMany()
-    //         .HasForeignKey(s => s.OriginId)
-    //         .IsRequired();
-    //     modelBuilder.Entity<Models.Spacelane>()
-    //         .HasOne(s => s.Destination)
-    //         .WithMany()
-    //         .HasForeignKey(s => s.DestinationId)
-    //         .IsRequired();
-    //     modelBuilder.Entity<Models.Spacelane>()
-    //         .HasNoKey();
-    //     #endregion Spacelane
-    //     #region Planet
-    //     modelBuilder.Entity<Models.Planet>()
-    //         .HasKey(p => p.Name);
-    //     modelBuilder.Entity<Models.Planet>()
-    //         .HasMany(p => p.ParentGovernments)
-    //         .WithOne(p => p.Planet)
-    //         .HasForeignKey(p => p.PlanetId)
-    //         .IsRequired();
-    //     #endregion Planet
-    //     #region Government
-    //     modelBuilder.Entity<Models.Government>()
-    //         .HasKey(g => g.Name);
-    //     modelBuilder.Entity<Models.Government>()
-    //         .Property(g => g.Color)
-    //             .HasConversion(
-    //                 v => v.ToString(),
-    //                 v => (MapColor)Enum.Parse(typeof(MapColor), v));
-    //     #endregion Government
-    //     #region GovernmentGovernment
-    //     modelBuilder.Entity<Models.GovernmentGovernment>()
-    //         .HasOne(g => g.ChildGovernment)
-    //         .WithMany()
-    //         .HasForeignKey(g => g.ChildGovernmentId)
-    //         .IsRequired();
-    //     modelBuilder.Entity<Models.GovernmentGovernment>()
-    //         .HasOne(g => g.ParentGovernment)
-    //         .WithMany()
-    //         .HasForeignKey(g => g.ParentGovernmentId)
-    //         .IsRequired();
-    //     modelBuilder.Entity<Models.GovernmentGovernment>()
-    //         .HasNoKey()
-    //         .Property(g => g.Relationship)
-    //             .HasConversion(
-    //                 v => v.ToString(),
-    //                 v => (GovernmentRelationship)Enum.Parse(typeof(GovernmentRelationship), v));
-    //     #endregion GovernmentGovernment
-    //     #region PlanetGovernment
     //     modelBuilder.Entity<Models.PlanetGovernment>()
     //         .HasOne(p => p.Government)
     //         .WithMany()

--- a/src/service/Data/GalaxyMapContext.cs
+++ b/src/service/Data/GalaxyMapContext.cs
@@ -22,18 +22,6 @@ public class GalaxyMapContext : DbContext {
             .WithOne(g => g.ChildGovernment)
             .HasForeignKey(g => g.ChildGovernmentId)
             .IsRequired();
-    //     modelBuilder.Entity<Models.PlanetGovernment>()
-    //         .HasOne(p => p.Government)
-    //         .WithMany()
-    //         .HasForeignKey(p => p.GovernmentId)
-    //         .IsRequired();
-    //     modelBuilder.Entity<Models.PlanetGovernment>()
-    //         .HasNoKey()
-    //         .Property(p => p.Relationship)
-    //             .HasConversion(
-    //                 v => v.ToString(),
-    //                 v => (GovernmentRelationship)Enum.Parse(typeof(GovernmentRelationship), v));
-    //     #endregion PlanetGovernment
     }
 
 }

--- a/src/service/GalaxyMapSiteApi.csproj
+++ b/src/service/GalaxyMapSiteApi.csproj
@@ -13,6 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="8.0.10" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.10" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>

--- a/src/service/Models/Government.cs
+++ b/src/service/Models/Government.cs
@@ -30,6 +30,7 @@ public class Government {
     }
     public Government GetGalacticGovernment() {
         Government parent = GetParentGovernment();
+        // @TODO(jaymirecki): replace this comparison with an IEquatable comparison
         if (parent.Name == this.Name){
             return parent;
         }

--- a/src/service/Models/Government.cs
+++ b/src/service/Models/Government.cs
@@ -1,0 +1,45 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using GalaxyMapSiteApi.Data;
+using GalaxyMapSiteApi.Models.Map;
+
+namespace GalaxyMapSiteApi.Models;
+
+[Table("governments")]
+public class Government {
+    #region Properties
+    [Key]
+    public string Name { get; set; }
+    [NotMapped]
+    public MapColor Color { get; set; } = MapColor.Gray;
+    public string ColorString {
+        get { return Color.ToString(); }
+        set { Color = (MapColor)Enum.Parse(typeof(MapColor), value); }
+    }
+    public virtual ICollection<PlanetGovernment> PlanetGovernments { get; set;} = [];
+    [NotMapped]
+    public List<Planet> Planets { 
+        get { return ((List<PlanetGovernment>)PlanetGovernments).ConvertAll(p => p.Planet); }
+    }
+    public virtual ICollection<GovernmentGovernment> ParentGovernments { get; set; } = [];
+    public Government GetParentGovernment() {
+        if (ParentGovernments.Count > 0) {
+            return ParentGovernments.First().ParentGovernment.GetParentGovernment();
+        }
+        return this;
+    }
+    public Government GetGalacticGovernment() {
+        Government parent = GetParentGovernment();
+        if (parent.Name == this.Name){
+            return parent;
+        }
+        return parent.GetGalacticGovernment();
+    }
+    #endregion Properties
+    #region Constructors
+    public Government(string name, string colorString) {
+        Name = name;
+        ColorString = colorString;
+    }
+    #endregion Constructors
+}

--- a/src/service/Models/GovernmentGovernment.cs
+++ b/src/service/Models/GovernmentGovernment.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace GalaxyMapSiteApi.Models;
+
+[Table("government_governments")]
+[PrimaryKey(nameof(ChildGovernmentId), nameof(ParentGovernmentId))]
+public class GovernmentGovernment {
+    #region Properties
+    public virtual Government ChildGovernment { get; set; } = null!;
+    [Key, Column(Order = 0)]
+    [ForeignKey(nameof(ChildGovernment))]
+    public string ChildGovernmentId { get; set; }
+    public virtual Government ParentGovernment { get; set; } = null!;
+    [Key, Column(Order = 1)]
+    [ForeignKey(nameof(ParentGovernment))]
+    public string ParentGovernmentId { get; set; }
+    [NotMapped]
+    public virtual GovernmentRelationship Relationship { get; set; }
+    public string RelationshipString {
+        get { return Relationship.ToString(); }
+        set { Relationship = (GovernmentRelationship)Enum.Parse(typeof(GovernmentRelationship), value); }
+    }
+    #endregion Properties
+    #region Constructors
+    public GovernmentGovernment(string childGovernmentId, string parentGovernmentId, string relationshipString) {
+        ChildGovernmentId = childGovernmentId;
+        ParentGovernmentId = parentGovernmentId;
+        RelationshipString = relationshipString;
+    }
+    #endregion Constructors
+}

--- a/src/service/Models/GovernmentRelationship.cs
+++ b/src/service/Models/GovernmentRelationship.cs
@@ -1,0 +1,7 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace GalaxyMapSiteApi.Models;
+
+public enum GovernmentRelationship {
+    Member,
+}

--- a/src/service/Models/Map/System.cs
+++ b/src/service/Models/Map/System.cs
@@ -10,11 +10,23 @@ public struct System {
     #endregion Properties
     #region Constructors
     public System(Models.System system) {
-        Name = system.Name;
+        if (system.Planets.Count > 0) {
+            Planet primaryPlanet = system.Planets.First();
+            Name = primaryPlanet.Name;
+            Console.WriteLine(primaryPlanet.CurrentGovernment?.Name);
+            Color = GetColorFromEnum(primaryPlanet.CurrentGovernment is not null ? primaryPlanet.CurrentGovernment.GetGalacticGovernment().Color: MapColor.Gray);
+        }
+        else {
+            Name = system.Name;
+            Color = GetColorFromEnum(MapColor.Gray);
+        }
         X = system.Coordinates.X;
         Y = system.Coordinates.Y;
-        Color = Enum.GetName(typeof(MapColor), MapColor.Gray) ?? "Gray";
         FocusLevel = FocusLevelConverter.convertFormap(system.Focus);
     }
     #endregion Constructors
+    private string GetColorFromEnum(MapColor color) {
+        Console.WriteLine(color);
+        return Enum.GetName(typeof(MapColor), color) ?? "Gray";
+    }
 }

--- a/src/service/Models/Planet.cs
+++ b/src/service/Models/Planet.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace GalaxyMapSiteApi.Models;
+
+[Table("planets")]
+public class Planet {
+    #region Properties
+    [Key]
+    public string Name { get; set; }
+    public virtual System System { get; set; } = null!;
+    public string SystemId { get; set; }
+    public virtual ICollection<PlanetGovernment> ParentGovernments { get; set;} = [];
+    [NotMapped]
+    public Government? CurrentGovernment {
+        get { Console.WriteLine(ParentGovernments.Count); return ParentGovernments.Count > 0 ? ParentGovernments.First().Government : null; }
+
+    }
+    #endregion Properties
+    #region Constructors
+    public Planet(string name, string systemId) {
+        Name = name;
+        SystemId = systemId;
+    }
+    #endregion Constructors
+    #region Overrides
+    public override string ToString()
+    {
+        return $"{{Name: '{Name}', SystemId: '{SystemId}'}}";
+    }
+    #endregion Overrides
+}

--- a/src/service/Models/PlanetGovernment.cs
+++ b/src/service/Models/PlanetGovernment.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace GalaxyMapSiteApi.Models;
+
+[Table("planet_governments")]
+[PrimaryKey(nameof(PlanetId), nameof(GovernmentId))]
+public class PlanetGovernment {
+    #region Properties
+    public virtual Planet Planet { get; set; } = null!;
+    [Key, Column(Order = 0)]
+    [ForeignKey(nameof(Planet))]
+    public string PlanetId { get; set; }
+    public virtual Government Government { get; set; } = null!;
+    [Key, Column(Order = 1)]
+    [ForeignKey(nameof(Government))]
+    public string GovernmentId { get; set; }
+    [NotMapped]
+    public GovernmentRelationship Relationship { get; set; }
+    public string RelationshipString {
+        get { return Relationship.ToString(); }
+        set { Relationship = (GovernmentRelationship)Enum.Parse(typeof(GovernmentRelationship), value); }
+    }
+    #endregion Properties
+    #region Constructors
+    public PlanetGovernment(string planetId, string governmentId, string relationshipString) {
+        PlanetId = planetId;
+        GovernmentId = governmentId;
+        RelationshipString = relationshipString;
+    }
+    #endregion Constructors
+}

--- a/src/service/Models/Spacelane.cs
+++ b/src/service/Models/Spacelane.cs
@@ -1,14 +1,18 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 
 namespace GalaxyMapSiteApi.Models;
 
 [Table("spacelanes")]
+[Keyless]
 public class Spacelane {
     #region Properties
     public string Name { get; set; }
-    public System Origin { get; set; } = null!;
+    public virtual System Origin { get; set; } = null!;
+    [ForeignKey(nameof(Origin))]
     public string OriginId { get; set; }
-    public System Destination { get; set; } = null!;
+    public virtual System Destination { get; set; } = null!;
+    [ForeignKey(nameof(Destination))]
     public string DestinationId { get; set; }
     public int Focus { get; set; }
     #endregion Properties

--- a/src/service/Models/System.cs
+++ b/src/service/Models/System.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace GalaxyMapSiteApi.Models;
@@ -5,6 +6,7 @@ namespace GalaxyMapSiteApi.Models;
 [Table("solar_systems")]
 public class System {
     #region Properties
+    [Key]
     public string Name { get; set; } = "";
     [NotMapped]
     public Coordinates Coordinates { get; set; }
@@ -19,6 +21,7 @@ public class System {
     public string Sector { get; set; } = "";
     public string Region { get; set; } = "";
     public int Focus { get; set; }
+    public virtual ICollection<Planet> Planets { get; } = [];
     #endregion Properties
     #region Constructors
     // public System(string name, Coordinates coordinates) {


### PR DESCRIPTION
## Summary
- Add support for lazy loading from DB
- Add planets
- Add governments
- Add planet-government relationships
- Add government-government relationships
- Use planet names for system names when a system has a planet
- Color planets by their galactic government

## Test plan

- Added local data for planets, governments, and relationships, as well as an additional system with no planets