### PR TITLE
chore: bump node from 20 to 22

### DIFF
--- a/src/client/components/oodreact/Draggable.tsx
+++ b/src/client/components/oodreact/Draggable.tsx
@@ -24,8 +24,8 @@ export interface IPosition {
 const defaultPosition: IPosition = { x: 0, y: 0 };
 
 export function Draggable(props: IDraggableProps) {
-  const draggableRef = useRef<HTMLDivElement>(null);
-  const staticRef = useRef<HTMLDivElement>(null);
+  const draggableRef = useRef<HTMLDivElement | null>(null);
+  const staticRef = useRef<HTMLDivElement | null>(null);
   const [position, setPosition] = useState(props.initialPosition);
   const [relativePosition, setRelativePosition] = useState(defaultPosition);
   const [isDragging, setIsDragging] = useState(false);
@@ -121,6 +121,6 @@ function diffPositions(first: IPosition, second: IPosition) {
   };
 }
 
-function getPositionFromRef(ref: RefObject<HTMLDivElement>) {
+function getPositionFromRef(ref: RefObject<HTMLDivElement | null>) {
   return ref.current ? ref.current.getBoundingClientRect() : defaultPosition;
 }

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -15,7 +15,7 @@
         "react-dom": "^19.0.0"
       },
       "devDependencies": {
-        "@types/node": "^20",
+        "@types/node": "^22",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "eslint": "^9",
@@ -845,13 +845,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.17.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.16.tgz",
-      "integrity": "sha512-vOTpLduLkZXePLxHiHsBLp98mHGnl8RptV4YAO3HfKO5UHjDvySGbxKtpYfy8Sx5+WKcgc45qNreJJRVM3L6mw==",
+      "version": "22.13.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.11.tgz",
+      "integrity": "sha512-iEUCUJoU0i3VnrCmgoWCXttklWcvoCIx4jzcP22fioIVSdTmjgoEvmAO/QPw6TcS9k5FrNgn4w7q5lGOd1CT5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@types/react": {
@@ -4851,9 +4851,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "dev": true,
       "license": "MIT"
     },

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@types/node": "^20",
+    "@types/node": "^22",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "eslint": "^9",


### PR DESCRIPTION
## Summary

This pull request bumps `node` from version `20` to `22`. As part of this, update the `oodreact` `Draggable` component type annotations to be compliant with new linting.

### Checklist

- [x] Fill out all sections of this pull request description
- [x] Assign this pull request to yourself
- [x] Add the following labels to this pull request:
    - [x] `effort: *` to describe the amount of effort required to review this pull request
    - [x] `type: *` to describe the type of change introduced in this pull request
    - [x] `work: *` to describe the complexity of the changes introduced by this pull request
- [x] Add at least one issue closed by this pull request. (If this pull request does not close an issue, consider adding an issue first.)

## Testing

- Used `just run` with test data and observed no issues, warnings, or errors.
- Used `just build` to ensure successful build


## Issues

Closes #139
