### PR TITLE
chore: bump to dotnet 9.0

### DIFF
--- a/.local/Dockerfile
+++ b/.local/Dockerfile
@@ -1,6 +1,7 @@
-FROM mcr.microsoft.com/dotnet/sdk@sha256:483d6f3faa583c93d522c4ca9ee54e08e535cb112dceb252b2fbb7ef94839cc8 
+# dotnet/sdk:9.0.202 https://mcr.microsoft.com/en-us/artifact/mar/dotnet/sdk/tags
+FROM mcr.microsoft.com/dotnet/sdk@sha256:d7f4691d11f610d9b94bb75517c9e78ac5799447b5b3e82af9e4625d8c8d1d53 AS build-service
 WORKDIR /app
-RUN curl --silent --location https://deb.nodesource.com/setup_20.x | bash - \
+RUN curl --silent --location https://deb.nodesource.com/setup_22.x | bash - \
 && apt-get install -y nodejs
 COPY ./run.sh .
 COPY ./restart-node.sh .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-service
+# dotnet/sdk:9.0.202 https://mcr.microsoft.com/en-us/artifact/mar/dotnet/sdk/tags
+FROM mcr.microsoft.com/dotnet/sdk@sha256:d7f4691d11f610d9b94bb75517c9e78ac5799447b5b3e82af9e4625d8c8d1d53 AS build-service
 WORKDIR /app
 
 COPY ./src/service .
@@ -7,10 +8,11 @@ RUN dotnet restore
 WORKDIR /app
 RUN dotnet publish -c release -o /out --no-restore
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-client
+# dotnet/sdk:9.0.202 https://mcr.microsoft.com/en-us/artifact/mar/dotnet/sdk/tags
+FROM mcr.microsoft.com/dotnet/sdk@sha256:d7f4691d11f610d9b94bb75517c9e78ac5799447b5b3e82af9e4625d8c8d1d53 AS build-client
 WORKDIR /app
 
-RUN curl --silent --location https://deb.nodesource.com/setup_20.x | bash - \
+RUN curl --silent --location https://deb.nodesource.com/setup_22.x | bash - \
 && apt-get install -y nodejs
 COPY ./src/client/package-lock.json .
 COPY ./src/client/package.json .
@@ -19,12 +21,13 @@ RUN npm install
 COPY ./src/client .
 RUN npm run build
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+# dotnet/aspnet:9.0.3 https://mcr.microsoft.com/en-us/artifact/mar/dotnet/aspnet/tags
+FROM mcr.microsoft.com/dotnet/aspnet@sha256:4f0ad314f83e6abeb6906e69d0f9c81a0d2ee51d362e035c7d3e6ac5743f5399 AS runtime
 WORKDIR /app
 
 RUN apt-get update -y
 RUN apt-get install curl -y
-RUN curl --silent --location https://deb.nodesource.com/setup_20.x | bash - \
+RUN curl --silent --location https://deb.nodesource.com/setup_22.x | bash - \
 && apt-get install -y nodejs
 ENV NODE_ENV=production
 RUN addgroup --system --gid 1001 nodejs

--- a/src/service/GalaxyMapSiteApi.csproj
+++ b/src/service/GalaxyMapSiteApi.csproj
@@ -1,22 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="8.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10">
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="9.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="8.0.10" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.10" />
-    <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="9.0.3" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="EFCore.NamingConventions" Version="9.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

This pull request bumps `dotnet` from version `8.0` to `9.0`. As part of this, the following nuget packages were updated:
- `Microsoft.AspNetCore.SpaServices.Extensions` from version `8.0.10` to version `9.0.3`
- `Microsoft.EntityFrameworkCore.Design` from version `8.0.10` to version `9.0.3`
- `Microsoft.EntityFrameworkCore.InMemory` from version `8.0.10` to version `9.0.3`
- `Microsoft.EntityFrameworkCore.Proxies` from version `8.0.10` to version `9.0.3`
- `Npgsql.EntityFrameworkCore.PostgreSQL` from version `8.0.10` to version `9.0.4`
- `EFCore.NamingConventions` from version `8.0.3` to version `9.0.0`
- `Swashbuckle.AspNetCore` from version `6.6.2` to version `8.0.0`

### Checklist

- [x] Fill out all sections of this pull request description
- [x] Assign this pull request to yourself
- [x] Add the following labels to this pull request:
    - [x] `effort: *` to describe the amount of effort required to review this pull request
    - [x] `type: *` to describe the type of change introduced in this pull request
    - [x] `work: *` to describe the complexity of the changes introduced by this pull request
- [x] Add at least one issue closed by this pull request. (If this pull request does not close an issue, consider adding an issue first.)

## Testing

- Used `just run` with test data and observed no issues, warnings, or errors.
- Used `just build` to ensure successful build


## Issues

Closes #140
