### PR TITLE
feat: create Organization class and OrganizationEntity base class

### DIFF
--- a/.local/db/add-db-data.sh
+++ b/.local/db/add-db-data.sh
@@ -16,6 +16,7 @@ copy_from_csv /data/db/solar-systems.csv solar_systems
 copy_from_csv /data/db/spacelanes.csv spacelanes
 copy_from_csv /data/db/spacelane-segments.csv spacelane_segments
 copy_from_csv /data/db/planets.csv planets
+copy_from_csv /data/db/organizations.csv organizations
 copy_from_csv /data/db/governments.csv governments
 copy_from_csv /data/db/planet-governments.csv planet_governments
-copy_from_csv /data/db/government-governments.csv government_governments
+copy_from_csv /data/db/organization-organizations.csv organization_organizations

--- a/.local/db/corporations.csv
+++ b/.local/db/corporations.csv
@@ -1,0 +1,2 @@
+instance_id,id,name,organization_id
+legends_base,gray,Gray,corp_gray

--- a/.local/db/government-governments.csv
+++ b/.local/db/government-governments.csv
@@ -1,4 +1,0 @@
-instance_id,child_id,parent_id,relationship_string
-legends_base,gray,red,Member
-legends_base,blue,green,Member
-legends_base,yellow,magenta,Member

--- a/.local/db/governments.csv
+++ b/.local/db/governments.csv
@@ -1,8 +1,8 @@
-instance_id,id,name,color_string
-legends_base,gray,Gray,Gray
-legends_base,red,Red,Red
-legends_base,blue,Blue,Blue
-legends_base,green,Green,Green
-legends_base,yellow,Yellow,Yellow
-legends_base,magenta,Magenta,Magenta
-legends_base,aqua,Aqua,Aqua
+instance_id,id,name,color_string,organization_id
+legends_base,gray,Gray,Gray,gov_gray
+legends_base,red,Red,Red,gov_red
+legends_base,blue,Blue,Blue,gov_blue
+legends_base,green,Green,Green,gov_green
+legends_base,yellow,Yellow,Yellow,gov_yellow
+legends_base,magenta,Magenta,Magenta,gov_magenta
+legends_base,aqua,Aqua,Aqua,gov_aqua

--- a/.local/db/organization-organizations.csv
+++ b/.local/db/organization-organizations.csv
@@ -1,4 +1,4 @@
-instance_id,child_id,parent_id,relationship_string
-legends_base,gov_gray,gov_red,Member
-legends_base,gov_blue,gov_green,Member
-legends_base,gov_yellow,gov_magenta,Member
+instance_id,child_id,parent_id,relationship_string,start_date
+legends_base,gov_gray,corp_gray,Member,-9935000
+legends_base,gov_blue,gov_green,Member,-9935000
+legends_base,gov_yellow,gov_magenta,Member,-9935000

--- a/.local/db/organization-organizations.csv
+++ b/.local/db/organization-organizations.csv
@@ -1,0 +1,4 @@
+instance_id,child_id,parent_id,relationship_string
+legends_base,gov_gray,gov_red,Member
+legends_base,gov_blue,gov_green,Member
+legends_base,gov_yellow,gov_magenta,Member

--- a/.local/db/organizations.csv
+++ b/.local/db/organizations.csv
@@ -1,0 +1,8 @@
+instance_id,id,organization_type
+legends_base,gov_gray,Government
+legends_base,gov_red,Government
+legends_base,gov_blue,Government
+legends_base,gov_green,Government
+legends_base,gov_yellow,Government
+legends_base,gov_magenta,Government
+legends_base,gov_aqua,Government

--- a/.local/db/organizations.csv
+++ b/.local/db/organizations.csv
@@ -6,3 +6,4 @@ legends_base,gov_green,Government
 legends_base,gov_yellow,Government
 legends_base,gov_magenta,Government
 legends_base,gov_aqua,Government
+legends_base,corp_gray,Corporation

--- a/src/service/Data/DateConverter.cs
+++ b/src/service/Data/DateConverter.cs
@@ -1,3 +1,4 @@
+using GalaxyMapSiteApi.Data;
 using GalaxyMapSiteApi.Models;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 

--- a/src/service/Data/EnumConverter.cs
+++ b/src/service/Data/EnumConverter.cs
@@ -9,6 +9,5 @@ public class EnumConverter<TEnum> : ValueConverter<TEnum, string>
         : base(
             enumValue => enumValue.ToString(),
             stringValue => EnumConverter.ConvertToEnumOrNull<TEnum>(stringValue) ?? default(TEnum)
-        )
-    { }
+        ) { }
 }

--- a/src/service/Data/EnumConverter.cs
+++ b/src/service/Data/EnumConverter.cs
@@ -1,0 +1,14 @@
+using GalaxyMapSiteApi.Data;
+using GalaxyMapSiteApi.Models;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+public class EnumConverter<TEnum> : ValueConverter<TEnum, string>
+    where TEnum : struct, Enum
+{
+    public EnumConverter()
+        : base(
+            enumValue => enumValue.ToString(),
+            stringValue => EnumConverter.ConvertToEnumOrNull<TEnum>(stringValue) ?? default(TEnum)
+        )
+    { }
+}

--- a/src/service/Data/EnumConverter.cs
+++ b/src/service/Data/EnumConverter.cs
@@ -8,6 +8,6 @@ public class EnumConverter<TEnum> : ValueConverter<TEnum, string>
     public EnumConverter()
         : base(
             enumValue => enumValue.ToString(),
-            stringValue => EnumConverter.ConvertToEnumOrNull<TEnum>(stringValue) ?? default(TEnum)
+            stringValue => EnumConverter.ConvertToEnumOrDefault<TEnum>(stringValue)
         ) { }
 }

--- a/src/service/Data/GalaxyMapContext.cs
+++ b/src/service/Data/GalaxyMapContext.cs
@@ -43,33 +43,8 @@ public class GalaxyMapContext : DbContext
             .Entity<Models.Organization>()
             .HasMany(o => o.ChildOrganizationRelationships)
             .WithOne(o => o.Parent);
-        // ParentOrganizations and ChildOrganizations
-        // modelBuilder
-        //     .Entity<Models.Organization>()
-        //     .HasMany(g => g.ParentOrganizations)
-        //     .WithMany(g => g.ChildOrganizations)
-        //     .UsingEntity<Models.OrganizationOrganization>(
-        //         j =>
-        //             j.HasOne(oo => oo.Parent)
-        //                 .WithMany()
-        //                 .HasForeignKey(oo => new { oo.InstanceId, oo.ParentId }),
-        //         j =>
-        //             j.HasOne(oo => oo.Child)
-        //                 .WithMany()
-        //                 .HasForeignKey(oo => new { oo.InstanceId, oo.ChildId }),
-        //         j =>
-        //         {
-        //             j.ToTable("organization_organizations");
-        //             j.HasKey(oo => new
-        //             {
-        //                 oo.InstanceId,
-        //                 oo.ChildId,
-        //                 oo.ParentId,
-        //             });
-        //         }
-        //     );
         #endregion Organization Relationships
-
+        #region Planet-Government Relationships
         modelBuilder
             .Entity<Models.Planet>()
             .HasMany(p => p.Governments)
@@ -94,5 +69,6 @@ public class GalaxyMapContext : DbContext
                     });
                 }
             );
+        #endregion Planet-Government Relationships
     }
 }

--- a/src/service/Data/GalaxyMapContext.cs
+++ b/src/service/Data/GalaxyMapContext.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using EFCore.NamingConventions;
 using GalaxyMapSiteApi.Models;
 using Microsoft.EntityFrameworkCore;
@@ -34,89 +35,39 @@ public class GalaxyMapContext : DbContext
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         #region Organization Relationships
+        modelBuilder
+            .Entity<Models.Organization>()
+            .HasMany(o => o.ParentOrganizationRelationships)
+            .WithOne(o => o.Child);
+        modelBuilder
+            .Entity<Models.Organization>()
+            .HasMany(o => o.ChildOrganizationRelationships)
+            .WithOne(o => o.Parent);
         // ParentOrganizations and ChildOrganizations
-        modelBuilder
-            .Entity<Models.Organization>()
-            .HasMany(g => g.ParentOrganizations)
-            .WithMany(g => g.ChildOrganizations)
-            .UsingEntity<Models.OrganizationOrganization>(
-                j =>
-                    j.HasOne(oo => oo.Parent)
-                        .WithMany()
-                        .HasForeignKey(oo => new { oo.InstanceId, oo.ParentId }),
-                j =>
-                    j.HasOne(oo => oo.Child)
-                        .WithMany()
-                        .HasForeignKey(oo => new { oo.InstanceId, oo.ChildId }),
-                j =>
-                {
-                    j.ToTable("organization_organizations");
-                    j.HasKey(oo => new
-                    {
-                        oo.InstanceId,
-                        oo.ChildId,
-                        oo.ParentId,
-                    });
-                }
-            );
-
-        // ParentGovernments
-        modelBuilder
-            .Entity<Models.Organization>()
-            .HasMany(g => g.ParentGovernments)
-            .WithMany()
-            .UsingEntity<Models.OrganizationOrganization>(
-                j =>
-                    j.HasOne(oo => oo.Parent)
-                        .WithMany()
-                        .HasForeignKey(oo => new { oo.InstanceId, oo.ParentId }),
-                j =>
-                    j.HasOne(oo => oo.Child)
-                        .WithMany()
-                        .HasForeignKey(oo => new { oo.InstanceId, oo.ChildId }),
-                j =>
-                {
-                    j.ToTable("organization_organizations");
-                    j.HasKey(oo => new
-                    {
-                        oo.InstanceId,
-                        oo.ChildId,
-                        oo.ParentId,
-                    });
-                    j.HasQueryFilter(oo =>
-                        oo.Parent.OrganizationType == OrganizationType.Government
-                    );
-                }
-            );
-
-        // ChildGovernments
-        modelBuilder
-            .Entity<Models.Organization>()
-            .HasMany(g => g.ChildGovernments)
-            .WithMany()
-            .UsingEntity<Models.OrganizationOrganization>(
-                j =>
-                    j.HasOne(oo => oo.Child)
-                        .WithMany()
-                        .HasForeignKey(oo => new { oo.InstanceId, oo.ChildId }),
-                j =>
-                    j.HasOne(oo => oo.Parent)
-                        .WithMany()
-                        .HasForeignKey(oo => new { oo.InstanceId, oo.ParentId }),
-                j =>
-                {
-                    j.ToTable("organization_organizations");
-                    j.HasKey(oo => new
-                    {
-                        oo.InstanceId,
-                        oo.ChildId,
-                        oo.ParentId,
-                    });
-                    j.HasQueryFilter(oo =>
-                        oo.Child.OrganizationType == OrganizationType.Government
-                    );
-                }
-            );
+        // modelBuilder
+        //     .Entity<Models.Organization>()
+        //     .HasMany(g => g.ParentOrganizations)
+        //     .WithMany(g => g.ChildOrganizations)
+        //     .UsingEntity<Models.OrganizationOrganization>(
+        //         j =>
+        //             j.HasOne(oo => oo.Parent)
+        //                 .WithMany()
+        //                 .HasForeignKey(oo => new { oo.InstanceId, oo.ParentId }),
+        //         j =>
+        //             j.HasOne(oo => oo.Child)
+        //                 .WithMany()
+        //                 .HasForeignKey(oo => new { oo.InstanceId, oo.ChildId }),
+        //         j =>
+        //         {
+        //             j.ToTable("organization_organizations");
+        //             j.HasKey(oo => new
+        //             {
+        //                 oo.InstanceId,
+        //                 oo.ChildId,
+        //                 oo.ParentId,
+        //             });
+        //         }
+        //     );
         #endregion Organization Relationships
 
         modelBuilder

--- a/src/service/Data/GalaxyMapContext.cs
+++ b/src/service/Data/GalaxyMapContext.cs
@@ -17,7 +17,9 @@ public class GalaxyMapContext : DbContext
     protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
     {
         configurationBuilder.Properties<Date>().HaveConversion<DateConverter>();
-        configurationBuilder.Properties<OrganizationType>().HaveConversion<EnumConverter<OrganizationType>>();
+        configurationBuilder
+            .Properties<OrganizationType>()
+            .HaveConversion<EnumConverter<OrganizationType>>();
     }
 
     public DbSet<Models.System> Systems { get; set; }
@@ -81,7 +83,9 @@ public class GalaxyMapContext : DbContext
                         oo.ChildId,
                         oo.ParentId,
                     });
-                    j.HasQueryFilter(oo => oo.Parent.OrganizationType == OrganizationType.Government);
+                    j.HasQueryFilter(oo =>
+                        oo.Parent.OrganizationType == OrganizationType.Government
+                    );
                 }
             );
 
@@ -108,7 +112,9 @@ public class GalaxyMapContext : DbContext
                         oo.ChildId,
                         oo.ParentId,
                     });
-                    j.HasQueryFilter(oo => oo.Child.OrganizationType == OrganizationType.Government);
+                    j.HasQueryFilter(oo =>
+                        oo.Child.OrganizationType == OrganizationType.Government
+                    );
                 }
             );
         #endregion Organization Relationships

--- a/src/service/Data/SystemsRepository.cs
+++ b/src/service/Data/SystemsRepository.cs
@@ -20,6 +20,8 @@ public class SystemsRepository
             .Where(s => s.InstanceId == instanceId)
             .Include(s => s.Planets)
             .ThenInclude(p => p.Governments)
+            .ThenInclude(g => g.Organization)
+            .ThenInclude(o => o.ParentOrganizations)
             .ToListAsync();
     }
 
@@ -34,8 +36,27 @@ public class SystemsRepository
                 && (s.StartDate == null || s.StartDate < new Date(date))
                 && (s.EndDate == null || s.EndDate > new Date(date))
             )
-            .Include(s => s.Planets)
-            .ThenInclude(p => p.Governments)
+            .Include(s =>
+                s.Planets.Where(p =>
+                    (p.StartDate == null || p.StartDate < new Date(date))
+                    && (p.EndDate == null || p.EndDate > new Date(date))
+                )
+            )
+            .ThenInclude(p =>
+                p.Governments.Where(g =>
+                    (g.StartDate == null || g.StartDate < new Date(date))
+                    && (g.EndDate == null || g.EndDate > new Date(date))
+                )
+            )
+            .ThenInclude(g => g.Organization)
+            .ThenInclude(o =>
+                o.ParentOrganizationRelationships.Where(por =>
+                    (por.StartDate == null || por.StartDate < new Date(date))
+                    && (por.EndDate == null || por.EndDate > new Date(date))
+                    && por.Parent.OrganizationType == OrganizationType.Government
+                )
+            )
+            .ThenInclude(por => por.Parent)
             .ToListAsync();
     }
 }

--- a/src/service/Models/Corporation.cs
+++ b/src/service/Models/Corporation.cs
@@ -1,0 +1,17 @@
+using System.Collections;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using GalaxyMapSiteApi.Data;
+using GalaxyMapSiteApi.Models.Map;
+using Microsoft.EntityFrameworkCore;
+
+namespace GalaxyMapSiteApi.Models;
+
+[Table("corporations")]
+public class Corporation : OrganizationEntity
+{
+    #region Properties
+    #endregion Properties
+    #region Constructors
+    #endregion Constructors
+}

--- a/src/service/Models/EnumConverter.cs
+++ b/src/service/Models/EnumConverter.cs
@@ -1,3 +1,6 @@
+using System.Globalization;
+using System.Threading.Tasks;
+
 namespace GalaxyMapSiteApi.Models;
 
 public class EnumConverter
@@ -20,5 +23,11 @@ public class EnumConverter
             return (TEnum)result;
         }
         return null;
+    }
+
+    public static TEnum ConvertToEnumOrDefault<TEnum>(string? value)
+        where TEnum : struct, Enum
+    {
+        return ConvertToEnumOrDefault(value, default(TEnum));
     }
 }

--- a/src/service/Models/Government.cs
+++ b/src/service/Models/Government.cs
@@ -8,10 +8,9 @@ using Microsoft.EntityFrameworkCore;
 namespace GalaxyMapSiteApi.Models;
 
 [Table("governments")]
-public class Government : InstanceEntity
+public class Government : OrganizationEntity
 {
     #region Properties
-    public string Name { get; set; }
 
     [NotMapped]
     public MapColor Color { get; set; } = MapColor.Gray;
@@ -20,29 +19,7 @@ public class Government : InstanceEntity
         get { return Color.ToString(); }
         set { Color = (MapColor)Enum.Parse(typeof(MapColor), value); }
     }
-    public virtual required ICollection<Planet> Planets { get; set; }
-    public virtual ICollection<Government> ParentGovernments { get; set; } = [];
-    public virtual ICollection<Government> ChildGovernments { get; set; } = [];
-
-    public Government GetParentGovernment()
-    {
-        if (ParentGovernments.Count > 0)
-        {
-            return ParentGovernments.First();
-        }
-        return this;
-    }
-
-    public Government GetGalacticGovernment()
-    {
-        Government parent = GetParentGovernment();
-        // @TODO(jaymirecki): replace this comparison with an IEquatable comparison
-        if (parent.Name == this.Name)
-        {
-            return parent;
-        }
-        return parent.GetGalacticGovernment();
-    }
+    public virtual ICollection<Planet> Planets { get; set; } = [];
     #endregion Properties
     #region Constructors
     public Government(string name, string colorString)
@@ -51,4 +28,15 @@ public class Government : InstanceEntity
         ColorString = colorString;
     }
     #endregion Constructors
+
+    public Government GetGalacticGovernment()
+    {
+        Government? parent = GetParentGovernment();
+        // @TODO(jaymirecki): replace this comparison with an IEquatable comparison
+        if (parent is null)
+        {
+            return this;
+        }
+        return parent.GetGalacticGovernment();
+    }
 }

--- a/src/service/Models/Map/System.cs
+++ b/src/service/Models/Map/System.cs
@@ -21,6 +21,9 @@ public struct System
                     ? primaryPlanet.CurrentGovernment.GetGalacticGovernment().Color
                     : MapColor.Gray
             );
+            Console.WriteLine(
+                $"System: {Name}, Governments: {string.Join(", ", primaryPlanet.CurrentGovernment.Organization.ParentGovernments.Select(g => g.ToString()))}, Organizations: {string.Join(", ", primaryPlanet.CurrentGovernment.ParentOrganizations.Select(g => g.ToString()))}"
+            );
         }
         else
         {

--- a/src/service/Models/Map/System.cs
+++ b/src/service/Models/Map/System.cs
@@ -21,9 +21,6 @@ public struct System
                     ? primaryPlanet.CurrentGovernment.GetGalacticGovernment().Color
                     : MapColor.Gray
             );
-            Console.WriteLine(
-                $"System: {Name}, Governments: {string.Join(", ", primaryPlanet.CurrentGovernment.Organization.ParentGovernments.Select(g => g.ToString()))}, Organizations: {string.Join(", ", primaryPlanet.CurrentGovernment.ParentOrganizations.Select(g => g.ToString()))}"
-            );
         }
         else
         {

--- a/src/service/Models/Organization.cs
+++ b/src/service/Models/Organization.cs
@@ -1,0 +1,40 @@
+using System.Collections;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using GalaxyMapSiteApi.Data;
+using GalaxyMapSiteApi.Models.Map;
+using Microsoft.EntityFrameworkCore;
+
+namespace GalaxyMapSiteApi.Models;
+
+[Table("organizations")]
+public class Organization : InstanceEntity
+{
+    #region Properties
+    public OrganizationType OrganizationType { get; set; }
+    public virtual Government? Government { get; set; }
+    public virtual Corporation? Corporation { get; set; }
+    public virtual ICollection<Organization> ParentOrganizations { get; set; } = [];
+    public virtual ICollection<Organization> ChildOrganizations { get; set; } = [];
+    public virtual ICollection<Organization> ParentGovernments { get; set; } = [];
+    public virtual ICollection<Organization> ChildGovernments { get; set; } = [];
+
+    [NotMapped]
+    public OrganizationEntity? OrganizationEntity
+    {
+        get
+        {
+            switch (OrganizationType)
+            {
+                case OrganizationType.Government:
+                    return Government;
+                case OrganizationType.Corporation:
+                    return Corporation;
+            }
+            return null;
+        }
+    }
+    #endregion Properties
+    #region Constructors
+    #endregion Constructors
+}

--- a/src/service/Models/Organization.cs
+++ b/src/service/Models/Organization.cs
@@ -14,10 +14,54 @@ public class Organization : InstanceEntity
     public OrganizationType OrganizationType { get; set; }
     public virtual Government? Government { get; set; }
     public virtual Corporation? Corporation { get; set; }
-    public virtual ICollection<Organization> ParentOrganizations { get; set; } = [];
-    public virtual ICollection<Organization> ChildOrganizations { get; set; } = [];
-    public virtual ICollection<Organization> ParentGovernments { get; set; } = [];
-    public virtual ICollection<Organization> ChildGovernments { get; set; } = [];
+    public virtual ICollection<OrganizationOrganization> ParentOrganizationRelationships { get; set; } =
+    [];
+    public virtual ICollection<OrganizationOrganization> ChildOrganizationRelationships { get; set; } =
+    [];
+    public virtual ICollection<Organization> ParentOrganizations
+    {
+        get { return ParentOrganizationRelationships.Select(r => r.Parent).ToList(); }
+    }
+    public virtual ICollection<Organization> ChildOrganizations
+    {
+        get { return ChildOrganizationRelationships.Select(r => r.Child).ToList(); }
+    }
+    public virtual ICollection<Organization> ParentGovernments
+    {
+        get
+        {
+            return ParentOrganizations
+                .Where(po => po.OrganizationType == OrganizationType.Government)
+                .ToList();
+        }
+    }
+    public virtual ICollection<Organization> ChildGovernments
+    {
+        get
+        {
+            return ChildOrganizations
+                .Where(co => co.OrganizationType == OrganizationType.Government)
+                .ToList();
+        }
+    }
+    public virtual ICollection<Organization> ParentCorporations
+    {
+        get
+        {
+            return ParentOrganizations
+                .Where(po => po.OrganizationType == OrganizationType.Corporation)
+                .ToList();
+        }
+    }
+    public virtual ICollection<Organization> ChildCorporations
+    {
+        get
+        {
+            return ChildOrganizations
+                .Where(co => co.OrganizationType == OrganizationType.Corporation)
+                .ToList();
+        }
+    }
 
     [NotMapped]
     public OrganizationEntity? OrganizationEntity
@@ -33,6 +77,11 @@ public class Organization : InstanceEntity
             }
             return null;
         }
+    }
+
+    public string ToString()
+    {
+        return $"{Id} - {OrganizationType}";
     }
     #endregion Properties
     #region Constructors

--- a/src/service/Models/OrganizationEntity.cs
+++ b/src/service/Models/OrganizationEntity.cs
@@ -20,28 +20,36 @@ public abstract class OrganizationEntity : InstanceEntity
     public ICollection<Organization> ParentOrganizations
     {
         get { return Organization.ParentOrganizations; }
-        set { Organization.ParentOrganizations = value; }
     }
 
     [NotMapped]
     public ICollection<Organization> ChildOrganizations
     {
         get { return Organization.ChildOrganizations; }
-        set { Organization.ChildOrganizations = value; }
     }
 
     [NotMapped]
     public ICollection<Organization> ParentGovernments
     {
         get { return Organization.ParentGovernments; }
-        set { Organization.ParentGovernments = value; }
     }
 
     [NotMapped]
     public ICollection<Organization> ChildGovernments
     {
         get { return Organization.ChildGovernments; }
-        set { Organization.ChildGovernments = value; }
+    }
+
+    [NotMapped]
+    public ICollection<Organization> ParentCorporations
+    {
+        get { return Organization.ParentCorporations; }
+    }
+
+    [NotMapped]
+    public ICollection<Organization> ChildCorporations
+    {
+        get { return Organization.ChildCorporations; }
     }
 
     public Government? GetParentGovernment()

--- a/src/service/Models/OrganizationEntity.cs
+++ b/src/service/Models/OrganizationEntity.cs
@@ -1,0 +1,56 @@
+using System.Collections;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using GalaxyMapSiteApi.Data;
+using GalaxyMapSiteApi.Models.Map;
+using Microsoft.EntityFrameworkCore;
+
+namespace GalaxyMapSiteApi.Models;
+
+public abstract class OrganizationEntity : InstanceEntity
+{
+    #region Properties
+    public required string Name { get; set; }
+
+    [ForeignKey("InstanceId, OrganizationId")]
+    public virtual required Organization Organization { get; set; } = null!;
+    public required string OrganizationId { get; set; }
+
+    [NotMapped]
+    public ICollection<Organization> ParentOrganizations
+    {
+        get { return Organization.ParentOrganizations; }
+        set { Organization.ParentOrganizations = value; }
+    }
+
+    [NotMapped]
+    public ICollection<Organization> ChildOrganizations
+    {
+        get { return Organization.ChildOrganizations; }
+        set { Organization.ChildOrganizations = value; }
+    }
+
+    [NotMapped]
+    public ICollection<Organization> ParentGovernments
+    {
+        get { return Organization.ParentGovernments; }
+        set { Organization.ParentGovernments = value; }
+    }
+
+    [NotMapped]
+    public ICollection<Organization> ChildGovernments
+    {
+        get { return Organization.ChildGovernments; }
+        set { Organization.ChildGovernments = value; }
+    }
+
+    public Government? GetParentGovernment()
+    {
+        if (ParentGovernments.Count > 0)
+        {
+            return ParentGovernments.First().Government;
+        }
+        return null;
+    }
+    #endregion Properties
+}

--- a/src/service/Models/OrganizationOrganization.cs
+++ b/src/service/Models/OrganizationOrganization.cs
@@ -4,24 +4,24 @@ using Microsoft.EntityFrameworkCore;
 
 namespace GalaxyMapSiteApi.Models;
 
-public class GovernmentGovernment : InstanceRelationship<Government, Government>
+public class OrganizationOrganization : InstanceRelationship<Organization, Organization>
 {
     #region Properties
 
     [NotMapped]
-    public virtual GovernmentRelationship Relationship { get; set; }
+    public virtual OrganizationRelationship Relationship { get; set; }
     public string RelationshipString
     {
         get { return Relationship.ToString(); }
         set
         {
-            Relationship = (GovernmentRelationship)
-                Enum.Parse(typeof(GovernmentRelationship), value);
+            Relationship = (OrganizationRelationship)
+                Enum.Parse(typeof(OrganizationRelationship), value);
         }
     }
     #endregion Properties
     #region Constructors
-    public GovernmentGovernment(string childId, string parentId, string relationshipString)
+    public OrganizationOrganization(string childId, string parentId, string relationshipString)
     {
         ChildId = childId;
         ParentId = parentId;

--- a/src/service/Models/OrganizationRelationship.cs
+++ b/src/service/Models/OrganizationRelationship.cs
@@ -2,7 +2,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace GalaxyMapSiteApi.Models;
 
-public enum GovernmentRelationship
+public enum OrganizationRelationship
 {
     Member,
 }

--- a/src/service/Models/OrganizationType.cs
+++ b/src/service/Models/OrganizationType.cs
@@ -1,0 +1,7 @@
+namespace GalaxyMapSiteApi.Models;
+
+public enum OrganizationType
+{
+    Government,
+    Corporation,
+}

--- a/src/service/Models/PlanetGovernment.cs
+++ b/src/service/Models/PlanetGovernment.cs
@@ -9,14 +9,14 @@ public class PlanetGovernment : InstanceRelationship<Planet, Government>
     #region Properties
 
     [NotMapped]
-    public GovernmentRelationship Relationship { get; set; }
+    public OrganizationRelationship Relationship { get; set; }
     public string RelationshipString
     {
         get { return Relationship.ToString(); }
         set
         {
-            Relationship = (GovernmentRelationship)
-                Enum.Parse(typeof(GovernmentRelationship), value);
+            Relationship = (OrganizationRelationship)
+                Enum.Parse(typeof(OrganizationRelationship), value);
         }
     }
     #endregion Properties


### PR DESCRIPTION
## Summary

This pull request creates the `Organization` class to manage relationships between and within different types of organizations (e.g. `Government` and `Corporation`).
- The `Organization` class contains lists of parent and child organizations, as well as specific lists for each type of organization.
    - These filtered lists were originally supposed to be implemented using `HasQueryFilter` so that all processing would happen in SQL rather than in memory, but EF Core requires `HasQueryFilter` to be global on an entity, so you can't set up separate filtered views of the same table and use them all at the same time.
    - Instead, this is implemented as just an in-memory filter on the parent/child organization lists.
    - Memory use is reduced by filtering the organization list in repositories.
- The `OrganizationOrganization` class defines relationships between organizations.
- The `OrganizationEntity` class is a base class for the classes that fully define each type of organization.

### Checklist

- [x] Fill out all sections of this pull request description
- [x] Assign this pull request to yourself
- [x] Add the following labels to this pull request:
    - [x] `effort: *` to describe the amount of effort required to review this pull request
    - [x] `type: *` to describe the type of change introduced in this pull request
    - [x] `work: *` to describe the complexity of the changes introduced by this pull request
- [x] Add at least one issue closed by this pull request. (If this pull request does not close an issue, consider adding an issue first.)

## Testing

Updated test data.

## Issues

Closes #250 
