### PR TITLE
chore: add db conversions for MapColor and FocusLevel

### DIFF
--- a/.local/db/governments.csv
+++ b/.local/db/governments.csv
@@ -1,4 +1,4 @@
-instance_id,id,name,color_string,organization_id
+instance_id,id,name,color,organization_id
 legends_base,gray,Gray,Gray,gov_gray
 legends_base,red,Red,Red,gov_red
 legends_base,blue,Blue,Blue,gov_blue

--- a/.local/db/solar-systems.csv
+++ b/.local/db/solar-systems.csv
@@ -1,4 +1,4 @@
-instance_id,id,name,x,y,sector,region,focus_string,start_date,end_date
+instance_id,id,name,x,y,sector,region,focus,start_date,end_date
 legends_base,gray_primary,Gray Primary,-8000,9000,,,Primary,-10120000,-9200
 legends_base,gray_secondary,Gray Secondary,-4000,9000,,,Secondary,-10120000,-9200
 legends_base,gray_tertiary,Gray Tertiary,0,9000,,,Tertiary,-10120000,-9200

--- a/.local/db/spacelanes.csv
+++ b/.local/db/spacelanes.csv
@@ -1,4 +1,4 @@
-instance_id,id,name,focus_string
+instance_id,id,name,focus
 legends_base,primary,Primary,Primary
 legends_base,secondary,Secondary,Secondary
 legends_base,tertiary,Tertiary,Tertiary

--- a/src/service/Data/GalaxyMapContext.cs
+++ b/src/service/Data/GalaxyMapContext.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using EFCore.NamingConventions;
 using GalaxyMapSiteApi.Models;
+using GalaxyMapSiteApi.Models.Map;
 using Microsoft.EntityFrameworkCore;
 
 namespace GalaxyMapSiteApi.Data;
@@ -21,6 +22,8 @@ public class GalaxyMapContext : DbContext
         configurationBuilder
             .Properties<OrganizationType>()
             .HaveConversion<EnumConverter<OrganizationType>>();
+        configurationBuilder.Properties<MapColor>().HaveConversion<EnumConverter<MapColor>>();
+        configurationBuilder.Properties<FocusLevel>().HaveConversion<EnumConverter<FocusLevel>>();
     }
 
     public DbSet<Models.System> Systems { get; set; }

--- a/src/service/Models/Government.cs
+++ b/src/service/Models/Government.cs
@@ -11,22 +11,10 @@ namespace GalaxyMapSiteApi.Models;
 public class Government : OrganizationEntity, IEquatable<Government>
 {
     #region Properties
-
-    [NotMapped]
-    public MapColor Color { get; set; } = MapColor.Gray;
-    public string ColorString
-    {
-        get { return Color.ToString(); }
-        set { Color = (MapColor)Enum.Parse(typeof(MapColor), value); }
-    }
+    public MapColor? Color { get; set; } = MapColor.Gray;
     public virtual ICollection<Planet> Planets { get; set; } = [];
     #endregion Properties
     #region Constructors
-    public Government(string name, string colorString)
-    {
-        Name = name;
-        ColorString = colorString;
-    }
     #endregion Constructors
 
     public Government GetGalacticGovernment()

--- a/src/service/Models/Spacelane.cs
+++ b/src/service/Models/Spacelane.cs
@@ -9,17 +9,7 @@ public class Spacelane : InstanceEntity
 {
     #region Properties
     public string Name { get; set; } = "";
-
-    [NotMapped]
     public FocusLevel? Focus { get; set; } = FocusLevel.Quaternary;
-    public string? FocusString
-    {
-        get { return Focus.ToString(); }
-        set
-        {
-            Focus = value is not null ? (FocusLevel)Enum.Parse(typeof(FocusLevel), value) : null;
-        }
-    }
     #endregion Properties
     #region Constructors
     #endregion Constructors

--- a/src/service/Models/System.cs
+++ b/src/service/Models/System.cs
@@ -24,17 +24,7 @@ public class System : InstanceEntity
     }
     public string? Sector { get; set; }
     public string? Region { get; set; }
-
-    [NotMapped]
-    public FocusLevel? Focus { get; set; }
-    public string? FocusString
-    {
-        get { return Focus.ToString(); }
-        set
-        {
-            Focus = value is not null ? (FocusLevel)Enum.Parse(typeof(FocusLevel), value) : null;
-        }
-    }
+    public FocusLevel? Focus { get; set; } = FocusLevel.Quaternary;
     public virtual ICollection<Planet> Planets { get; } = [];
     #endregion Properties
     /// <summary>


### PR DESCRIPTION
## Summary

This pull request adds db conversions for `MapColor` and `FocusLevel`. There should be no user facing changes, the only functional change is to the database, which will no longer have `color_string` or `focus_string` columns.

### Checklist

- [x] Fill out all sections of this pull request description
- [x] Assign this pull request to yourself
- [x] Add the following labels to this pull request:
    - [x] `effort: *` to describe the amount of effort required to review this pull request
    - [x] `type: *` to describe the type of change introduced in this pull request
    - [x] `work: *` to describe the complexity of the changes introduced by this pull request
- [x] Add at least one issue closed by this pull request. (If this pull request does not close an issue, consider adding an issue first.)

## Testing

Ran locally with test data and updated local test data.

## Issues

Closes #256 