### PR TITLE
feat: support moons and asteroids

### DIFF
--- a/.local/db/add-db-data.sh
+++ b/.local/db/add-db-data.sh
@@ -15,8 +15,8 @@ PGPASSWORD=password $POSTGRES_COMMAND "COPY instances FROM '/data/db/instances.c
 copy_from_csv /data/db/solar-systems.csv solar_systems
 copy_from_csv /data/db/spacelanes.csv spacelanes
 copy_from_csv /data/db/spacelane-segments.csv spacelane_segments
-copy_from_csv /data/db/planets.csv planets
+copy_from_csv /data/db/planets.csv orbiting_bodies
 copy_from_csv /data/db/organizations.csv organizations
 copy_from_csv /data/db/governments.csv governments
-copy_from_csv /data/db/planet-governments.csv planet_governments
+copy_from_csv /data/db/planet-governments.csv orbiting_body_governments
 copy_from_csv /data/db/organization-organizations.csv organization_organizations

--- a/src/service/Controllers/Map.cs
+++ b/src/service/Controllers/Map.cs
@@ -46,7 +46,10 @@ public class MapController : ControllerBase
             _context.SpacelaneSegments
         );
         List<Models.System> systems =
-            await systemsRepo.GetAllSystemsForInstanceDateWithPlanetGovernments(instanceId, date);
+            await systemsRepo.GetAllSystemsForInstanceDateWithOrbitingBodyGovernments(
+                instanceId,
+                date
+            );
         List<Models.SpacelaneSegment> spacelanes =
             await segmentsRepo.GetAllSpacelaneSegmentsForInstanceDateWithSpacelaneOriginDestination(
                 instanceId,

--- a/src/service/Data/GalaxyMapContext.cs
+++ b/src/service/Data/GalaxyMapContext.cs
@@ -29,7 +29,7 @@ public class GalaxyMapContext : DbContext
     public DbSet<Models.System> Systems { get; set; }
     public DbSet<Models.Spacelane> Spacelanes { get; set; }
     public DbSet<Models.SpacelaneSegment> SpacelaneSegments { get; set; }
-    public DbSet<Models.Planet> Planets { get; set; }
+    public DbSet<Models.OrbitingBody> OrbitingBodies { get; set; }
     public DbSet<Models.Government> Governments { get; set; }
     public DbSet<Models.OrganizationOrganization> OrganizationOrganizations { get; set; }
     public DbSet<Models.Instance> Instances { get; set; }
@@ -47,12 +47,12 @@ public class GalaxyMapContext : DbContext
             .HasMany(o => o.ChildOrganizationRelationships)
             .WithOne(o => o.Parent);
         #endregion Organization Relationships
-        #region Planet-Government Relationships
+        #region OrbitingBody-Government Relationships
         modelBuilder
-            .Entity<Models.Planet>()
+            .Entity<Models.OrbitingBody>()
             .HasMany(p => p.Governments)
-            .WithMany(g => g.Planets)
-            .UsingEntity<Models.PlanetGovernment>(
+            .WithMany(g => g.OrbitingBodies)
+            .UsingEntity<Models.OrbitingBodyGovernment>(
                 j =>
                     j.HasOne(pg => pg.Parent)
                         .WithMany()
@@ -63,7 +63,7 @@ public class GalaxyMapContext : DbContext
                         .HasForeignKey(pg => new { pg.InstanceId, pg.ChildId }),
                 j =>
                 {
-                    j.ToTable("planet_governments");
+                    j.ToTable("orbiting_body_governments");
                     j.HasKey(pg => new
                     {
                         pg.InstanceId,
@@ -72,6 +72,6 @@ public class GalaxyMapContext : DbContext
                     });
                 }
             );
-        #endregion Planet-Government Relationships
+        #endregion OrbitingBody-Government Relationships
     }
 }

--- a/src/service/Data/SystemsRepository.cs
+++ b/src/service/Data/SystemsRepository.cs
@@ -12,20 +12,20 @@ public class SystemsRepository
         Systems = systems;
     }
 
-    public async Task<List<Models.System>> GetAllSystemsForInstanceWithPlanetGovernments(
+    public async Task<List<Models.System>> GetAllSystemsForInstanceWithOrbitingBodyGovernments(
         string instanceId
     )
     {
         return await Systems
             .Where(s => s.InstanceId == instanceId)
-            .Include(s => s.Planets)
+            .Include(s => s.OrbitingBodies)
             .ThenInclude(p => p.Governments)
             .ThenInclude(g => g.Organization)
             .ThenInclude(o => o.ParentOrganizations)
             .ToListAsync();
     }
 
-    public async Task<List<Models.System>> GetAllSystemsForInstanceDateWithPlanetGovernments(
+    public async Task<List<Models.System>> GetAllSystemsForInstanceDateWithOrbitingBodyGovernments(
         string instanceId,
         int date
     )
@@ -37,7 +37,7 @@ public class SystemsRepository
                 && (s.EndDate == null || s.EndDate > new Date(date))
             )
             .Include(s =>
-                s.Planets.Where(p =>
+                s.OrbitingBodies.Where(p =>
                     (p.StartDate == null || p.StartDate < new Date(date))
                     && (p.EndDate == null || p.EndDate > new Date(date))
                 )

--- a/src/service/Models/Government.cs
+++ b/src/service/Models/Government.cs
@@ -12,7 +12,7 @@ public class Government : OrganizationEntity, IEquatable<Government>
 {
     #region Properties
     public MapColor? Color { get; set; } = MapColor.Gray;
-    public virtual ICollection<Planet> Planets { get; set; } = [];
+    public virtual ICollection<OrbitingBody> OrbitingBodies { get; set; } = [];
     #endregion Properties
     #region Constructors
     #endregion Constructors

--- a/src/service/Models/Map/System.cs
+++ b/src/service/Models/Map/System.cs
@@ -12,13 +12,13 @@ public struct System
     #region Constructors
     public System(Models.System system)
     {
-        if (system.Planets.Count > 0)
+        if (system.OrbitingBodies.Count > 0)
         {
-            Planet primaryPlanet = system.Planets.First();
-            Name = primaryPlanet.Name;
+            OrbitingBody primaryBody = system.OrbitingBodies.First();
+            Name = primaryBody.Name;
             Color = Map.GetColorFromEnum(
-                primaryPlanet.CurrentGovernment is not null
-                    ? primaryPlanet.CurrentGovernment.GetGalacticGovernment()?.Color
+                primaryBody.CurrentGovernment is not null
+                    ? primaryBody.CurrentGovernment.GetGalacticGovernment()?.Color
                     : MapColor.Gray
             );
         }

--- a/src/service/Models/OrbitingBody.cs
+++ b/src/service/Models/OrbitingBody.cs
@@ -3,15 +3,20 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace GalaxyMapSiteApi.Models;
 
-[Table("planets")]
-public class Planet : InstanceEntity
+[Table("orbiting_bodies")]
+public class OrbitingBody : InstanceEntity
 {
     #region Properties
     public string Name { get; set; }
 
     [ForeignKey("InstanceId, SystemId")]
-    public virtual System System { get; set; } = null!;
-    public string SystemId { get; set; }
+    public virtual required System System { get; set; }
+    public required string SystemId { get; set; }
+    public OrbitingBodyType? Type { get; set; }
+
+    [ForeignKey("InstanceId, OrbitedBodyId")]
+    public virtual OrbitingBody? OrbitedBody { get; set; }
+    public string? OrbitedBodyId { get; set; }
     public virtual ICollection<Government> Governments { get; set; } = [];
 
     [NotMapped]
@@ -20,17 +25,4 @@ public class Planet : InstanceEntity
         get { return Governments.Count > 0 ? Governments.First() : null; }
     }
     #endregion Properties
-    #region Constructors
-    public Planet(string name, string systemId)
-    {
-        Name = name;
-        SystemId = systemId;
-    }
-    #endregion Constructors
-    #region Overrides
-    public override string ToString()
-    {
-        return $"{{Name: '{Name}', SystemId: '{SystemId}'}}";
-    }
-    #endregion Overrides
 }

--- a/src/service/Models/OrbitingBodyGovernment.cs
+++ b/src/service/Models/OrbitingBodyGovernment.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace GalaxyMapSiteApi.Models;
 
-public class PlanetGovernment : InstanceRelationship<Planet, Government>
+public class OrbitingBodyGovernment : InstanceRelationship<OrbitingBody, Government>
 {
     #region Properties
 
@@ -20,12 +20,4 @@ public class PlanetGovernment : InstanceRelationship<Planet, Government>
         }
     }
     #endregion Properties
-    #region Constructors
-    public PlanetGovernment(string childId, string parentId, string relationshipString)
-    {
-        ChildId = childId;
-        ParentId = parentId;
-        RelationshipString = relationshipString;
-    }
-    #endregion Constructors
 }

--- a/src/service/Models/OrbitingBodyType.cs
+++ b/src/service/Models/OrbitingBodyType.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace GalaxyMapSiteApi.Models;
+
+public enum OrbitingBodyType
+{
+    Planet,
+    Moon,
+    Asteroid,
+}

--- a/src/service/Models/OrganizationOrganization.cs
+++ b/src/service/Models/OrganizationOrganization.cs
@@ -15,8 +15,10 @@ public class OrganizationOrganization : InstanceRelationship<Organization, Organ
         get { return Relationship.ToString(); }
         set
         {
-            Relationship = (OrganizationRelationship)
-                Enum.Parse(typeof(OrganizationRelationship), value);
+            Relationship = EnumConverter.ConvertToEnumOrDefault<OrganizationRelationship>(
+                value,
+                OrganizationRelationship.Member
+            );
         }
     }
     #endregion Properties

--- a/src/service/Models/System.cs
+++ b/src/service/Models/System.cs
@@ -25,7 +25,7 @@ public class System : InstanceEntity
     public string? Sector { get; set; }
     public string? Region { get; set; }
     public FocusLevel? Focus { get; set; } = FocusLevel.Quaternary;
-    public virtual ICollection<Planet> Planets { get; } = [];
+    public virtual ICollection<OrbitingBody> OrbitingBodies { get; } = [];
     #endregion Properties
     /// <summary>
     /// Gets the government that currently controls this system.
@@ -35,7 +35,7 @@ public class System : InstanceEntity
     {
         // @TODO(jmirecki): This just gets the government of the first planet
         // in the system with a government. This should be updated to find the
-        // common government among all planets in the system.
-        return Planets.Select(p => p.CurrentGovernment).FirstOrDefault();
+        // common government among all orbiting bodies in the system.
+        return OrbitingBodies.Select(p => p.CurrentGovernment).FirstOrDefault();
     }
 }


### PR DESCRIPTION
## Summary

This pull request converst `Planet` and `PlanetGovernment` classes into `OrbitalBody` and `OrbitalBodyGovernment` classes and adds an enumerator to specify the type of orbital body: planet, asteroid, or moon.

### Checklist

- [x] Fill out all sections of this pull request description
- [x] Assign this pull request to yourself
- [x] Add the following labels to this pull request:
    - [x] `effort: *` to describe the amount of effort required to review this pull request
    - [x] `type: *` to describe the type of change introduced in this pull request
    - [x] `work: *` to describe the complexity of the changes introduced by this pull request
- [x] Add at least one issue closed by this pull request. (If this pull request does not close an issue, consider adding an issue first.)

## Testing

Tested with production data.

## Issues

Closes #291 
